### PR TITLE
Add Habitat example packaging

### DIFF
--- a/habitat/README.md
+++ b/habitat/README.md
@@ -1,0 +1,38 @@
+This project is packaged by Habitat with the plan.sh, config, and hooks in this directory. This is provided for example purposes for others to draw from to build their own Java web applications that run under Tomcat.
+
+By default, `spring-petclinic` will use its HSQL in-memory database, which requires no additional configuration. However, the application supports connecting to a MySQL database. To provide this as an example setup, we run `core/mysql` on a separate system with Habitat. The `app_username` and `app_password` configuration needs to be set for MySQL. For example, this `mysql-petclinic.toml`:
+
+```
+root_password = "zanzibar"
+app_username  = "pc"
+app_password  = "pc"
+bind          = "0.0.0.0"
+```
+
+Then start MySQL, for example, with Docker:
+
+```
+docker run -it -p 3306:3306 -e HAB_MYSQL="$(cat mysql-petclinic.toml)" core/mysql --bind database:mysql.default
+```
+
+This package configures the application at run time with `-D` command-line options for `catalina.sh`. These are set with `server.catalina-opts`. The settings `database.username`, `database.password`, and `database.use-hsqldb` are required. For example, this `spring-petclinic.toml`:
+
+```
+[server]
+catalina-opts = "-Djava.security.egd=file:/dev/./urandom -Djdbc.driverClassName=com.mysql.jdbc.Driver -Djdbc.initLocation=classpath:db/mysql/initDB.sql -Djdbc.dataLocation=classpath:db/mysql/populateDB.sql -Djdbc.username=pc -Djdbc.password=pc -Djpa.database=MYSQL -Djdbc.url=jdbc:mysql://172.17.0.3:3306/petclinic"
+
+[database]
+username = "pc"
+password = "pc"
+use-hsqldb = false
+```
+
+We have to use the `-D` "jdbc" options here because the `data-access.properties` file is hardcoded in the application to come from the class path, and we don't have a way to override that with another properties file. When packaging your own Java application with Habitat, we strongly recommend writing it so that any configuration properties can be managed with Habitat as `config` [files](https://www.habitat.sh/docs/create-packages-configure/).
+
+Once the `toml` file above is created, the spring-petclinic application can be run, for example, in Docker:
+
+```
+docker run -it -p 8080:8080 -e HAB_SPRING_PETCLINIC="$(cat spring-petclinic.toml)" -it core/spring-petclinic --peer 172.17.0.3 --bind database:mysql.default
+```
+
+Replace `172.17.0.3` with the IP address of the MySQL container started earlier.

--- a/habitat/config/conf_server.xml
+++ b/habitat/config/conf_server.xml
@@ -1,0 +1,161 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="{{cfg.server.shutdown-port}}" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="{{cfg.server.port}}" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="{{cfg.server.redirect-port}}" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation with the JSSE engine. When
+         using the JSSE engine, the JSSE configuration attributes must be used.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation. When using the
+         APR/native implementation or the OpenSSL engine with NIO or NIO2 then
+         the OpenSSL configuration attributes must be used.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+{{~#if cfg.server.enable-ajp-connector}}
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <Connector port="{{cfg.server.ajp-port}}" protocol="AJP/1.3" redirectPort="{{cfg.server.redirect-port}}" />
+{{~/if}}
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="{{cfg.host.localhost.unpack-wars}}" autoDeploy="{{cfg.host.localhost.auto-deploy}}">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/habitat/config/conf_tomcat-users.xml
+++ b/habitat/config/conf_tomcat-users.xml
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+<!--
+  NOTE:  By default, no user is included in the "manager-gui" role required
+  to operate the "/manager/html" web application.  If you wish to use this app,
+  you must define such a user - the username and password are arbitrary. It is
+  strongly recommended that you do NOT use one of the users in the commented out
+  section below since they are intended for use with the examples web
+  application.
+-->
+<!--
+  NOTE:  The sample user and role entries below are intended for use with the
+  examples web application. They are wrapped in a comment and thus are ignored
+  when reading this file. If you wish to configure these users for use with the
+  examples web application, do not forget to remove the <!.. ..> that surrounds
+  them. You will also need to set the passwords to something appropriate.
+-->
+<!--
+  <role rolename="tomcat"/>
+  <role rolename="role1"/>
+  <user username="tomcat" password="<must-be-changed>" roles="tomcat"/>
+  <user username="both" password="<must-be-changed>" roles="tomcat,role1"/>
+  <user username="role1" password="<must-be-changed>" roles="role1"/>
+-->
+{{~#each cfg.userdbrealm.roles}}
+  <role rolename="{{this}}"/>
+{{~/each}}
+{{~#each cfg.userdbrealm.users}}
+  {{~#if password}}
+  <user username="{{username}}" password="{{password}}" roles="{{roles}}"/>
+  {{~/if}}
+{{~/each}}
+</tomcat-users>

--- a/habitat/config/webapps_host-manager_META-INF_context.xml
+++ b/habitat/config/webapps_host-manager_META-INF_context.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<Context antiResourceLocking="false" privileged="true" >
+{{#if cfg.host-manager.localhost-only}}
+  <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+         allow="127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1" />
+{{/if}}
+</Context>

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,0 +1,82 @@
+[server]
+port = "8080"
+shutdown-port = "8005"
+redirect-port = "8443"
+
+# Configuration for the AJP connector
+enable-ajp-connector = false
+ajp-port = "8009"
+
+# Tomcat utilizes SecureRandom to provide random values for session ids.  When starting Tomcat under
+# a newly created Habitat supervisor, Docker Container, etc., there is a long (> 50 seconds) delay
+# where SecureRandom gathers enough entropy to return random values.  To avoid this, a non-blocking
+# PRNG is passed to Tomcat for faster start up times.
+catalina-opts = "-Djava.security.egd=file:/dev/./urandom"
+
+# Per `config/conf_tomcat-users.xml`:
+# NOTE:  By default, no user is included in the "manager-gui" role required
+# to operate the "/manager/html" web application.  If you wish to use this app,
+# you must define such a user - the username and password are
+# arbitrary.
+#
+# The userdbrealm table contains roles and users. The users have their
+# roles defined which must exist in the toplevel roles list. There are
+# no roles or users defined in the default tomcat configuration that
+# ships with tomcat itself, so we don't define any by default. To
+# create roles and users at runtime, specify them in a user-supplied
+# TOML configuration like this:
+#
+# [userdbrealm]
+# roles = ["manager-gui", "manager-script", "manager-jmx", "manager-status"]
+#
+# [[userdbrealm.users]]
+# username = "admin"
+# password = "super-secret-password"
+# roles = "manager-gui,manager-script,manager-jmx,manager-status"
+
+# [[userdbrealm.users]]
+# username = "someuser"
+# password = false
+# roles = "manager-gui"
+#
+# This will be rendered in `conf_tomcat-users.xml` like this:
+#
+# <role rolename="manager-gui"/>
+# <role rolename="manager-script"/>
+# <role rolename="manager-jmx"/>
+# <role rolename="manager-status"/>
+# <user username="admin" password="super-secret-password" roles="manager-gui,manager-script,manager-jmx,manager-status"/>
+[userdbrealm]
+roles = []
+
+[[userdbrealm.users]]
+
+[host]
+
+[host.localhost]
+unpack-wars = true
+auto-deploy = true
+
+[host-manager]
+localhost-only = false
+
+# Configure the database for Pet Clinic. This uses the in-memory
+# HSQLDB per Pet Clinic's defaults. To configure MySQL, use something
+# like the commented-out example at the end of this file.
+[database]
+use-hsqldb = true
+host = "localhost"
+
+### Example for MySQL ###
+# The database server will be automatically selected from the Habitat
+# supervisor ring if `url` is not specified. Be sure to configure the
+# same username and password at run time for the MySQL service as used
+# here.
+#
+# [database]
+# use-hsqldb = false
+# driver-class-name = "com.mysql.jdbc.Driver"
+# url = jdbc:mysql://localhost:3306/petclinic?useUnicode=true&characterEncoding=UTF-8
+# username = "petclinic"
+# password = "petclinic"
+### End MySQL Example ###

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Move directories that ship in the package into place
+cp -a $(hab pkg path core/tomcat8)/tc {{pkg.svc_var_path}}/
+
+# Symlink config files into $TOMCAT_HOME/conf
+for file in $(cd {{pkg.svc_config_path}}; ls -1)
+do
+  echo "Linking $file"
+  target="${file//_//}"
+  ln -vsf {{pkg.svc_config_path}}/$file {{pkg.svc_var_path}}/tc/$target
+done
+
+chown -R hab:hab {{pkg.svc_path}}/*
+
+echo "Done preparing TOMCAT_HOME"
+
+{{~#if bind.has_database}}
+echo "Creating 'petclinic' database on {{bind.database.me.ip}}"
+mysql -h {{bind.database.me.ip}} -u {{cfg.database.username}} -p{{cfg.database.password}} -e 'CREATE DATABASE IF NOT EXISTS petclinic;'
+{{~/if}}
+
+echo "Copying 'petclinic.war' to {{pkg.svc_var_path}}/tc/webapps"
+cp {{pkg.path}}/petclinic.war {{pkg.svc_var_path}}/tc/webapps

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+exec 2>&1
+
+export JAVA_HOME=$(hab pkg path core/jdk8)
+export TOMCAT_HOME="{{pkg.svc_var_path}}/tc"
+export CATALINA_OPTS="{{cfg.server.catalina-opts}}"
+
+exec chpst -u hab:hab ${TOMCAT_HOME}/bin/catalina.sh run

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,59 @@
+pkg_name=spring-petclinic
+pkg_origin=jtimberman
+pkg_version=4.2.6
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('Apache-2.0')
+pkg_source=${pkg_name}-${pkg_version}.tar.bz2
+pkg_shasum="calculated"
+pkg_upstream_url=https://github.com/habitat-sh/spring-petclinic
+pkg_description="A sample Spring-based application, customized by the Habitat maintainers for example purposes"
+
+pkg_expose=(8080)
+
+pkg_deps=(
+  core/glibc
+  core/tomcat8
+  core/jre8
+  core/mysql
+)
+
+pkg_build_deps=(
+  core/maven
+  core/jdk8
+  core/which
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+)
+
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+pkg_svc_user="root"
+pkg_svc_group="root"
+
+do_begin() {
+  return 0
+}
+
+do_build() {
+  export JAVA_HOME=$(hab pkg path core/jdk8)
+  mvn package
+}
+
+do_install() {
+  cp $HAB_CACHE_SRC_PATH/${pkg_dirname}/target/petclinic.war $pkg_prefix
+}
+
+do_download() {
+  pushd ../
+  build_line "Creating ${pkg_name}-${pkg_version}.tar.bz2 from application source"
+  tar -cjf $HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}.tar.bz2 \
+		  --transform "s,^\.,spring-petclinic-${pkg_version}," \
+      --exclude .git --exclude habitat .
+  popd
+  pkg_shasum=$(trim $(sha256sum /hab/cache/src/${pkg_name}-${pkg_version}.tar.bz2 | cut -d " " -f 1))
+}

--- a/pom.xml
+++ b/pom.xml
@@ -186,11 +186,11 @@
         </dependency>
 
         <!-- For MySql only -->
-        <!--dependency>
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql-driver.version}</version>
-        </dependency-->
+        </dependency>
 
         <!-- HIBERNATE -->
         <dependency>

--- a/src/main/resources/db/mysql/initDB.sql
+++ b/src/main/resources/db/mysql/initDB.sql
@@ -4,8 +4,6 @@ ALTER DATABASE petclinic
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
 
-GRANT ALL PRIVILEGES ON petclinic.* TO pc@localhost IDENTIFIED BY 'pc';
-
 USE petclinic;
 
 CREATE TABLE IF NOT EXISTS vets (

--- a/src/main/resources/spring/datasource-config.xml
+++ b/src/main/resources/spring/datasource-config.xml
@@ -22,8 +22,8 @@
     <!-- (in this case, JDBC-related settings for the dataSource definition below) -->
     <context:property-placeholder location="classpath:spring/data-access.properties" system-properties-mode="OVERRIDE"/>
 
-    <!-- DataSource configuration for the tomcat jdbc connection pool 
-    See here for more details on commons-dbcp versus tomcat-jdbc: 
+    <!-- DataSource configuration for the tomcat jdbc connection pool
+    See here for more details on commons-dbcp versus tomcat-jdbc:
     http://blog.ippon.fr/2013/03/13/improving-the-performance-of-the-spring-petclinic-sample-application-part-3-of-5/-->
     <bean id="dataSource" class="org.apache.tomcat.jdbc.pool.DataSource"
           p:driverClassName="${jdbc.driverClassName}" p:url="${jdbc.url}"


### PR DESCRIPTION
This commit adds packaging for this application with Habitat. It uses
custom configuration via the catalina-opts, and can connect to a mysql
database running on another system, discoverable through the `peer`
and `bind` options to the `hab start` command. See the README.md in
the habitat directory.

Signed-off-by: jtimberman <joshua@chef.io>